### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ crate-type = ["rlib", "dylib"]
 cbindings = ["libc"]
 
 [dependencies]
-ring = "0.12"
+ring = "0.13"
 base32 = "^0.3.0"
 time = "^0.1.31"
-rand = "0.3.15"
-nom = "^2.2.1"
+rand = "0.5.0"
+hex = "0.3.2"
 
 [dependencies.libc]
-version = "^0.1.8"
+version = "^0.2"
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,8 +84,7 @@ extern crate base32;
 extern crate ring;
 extern crate rand;
 extern crate time;
-#[macro_use]
-extern crate nom;
+extern crate hex;
 
 pub mod oath;
 pub mod pass;

--- a/src/parser/hex.rs
+++ b/src/parser/hex.rs
@@ -56,38 +56,11 @@
  */
 
 
-use nom::{IResult,be_u8,is_hex_digit};
-
-fn hex_ascii_to_val(c: u8) -> u8 {
-    match c {
-        b'0'...b'9' => c - b'0',
-        b'a'...b'f' => c - b'a' + 10,
-        b'A'...b'F' => c - b'A' + 10,
-        _ => 0,
-    }
-}
-
-named!(get_hex_char<u8>, verify!(be_u8, is_hex_digit));
-
-named!(get_hex_couple<Vec<u8>>, count!(get_hex_char, 2));
-
-named!(parse_hex_couple<u8>, map!(get_hex_couple, |v: Vec<u8>| hex_ascii_to_val(v[0]) * 16 + hex_ascii_to_val(v[1])));
-
-named!(parse_hex_str<Vec<u8>>, fold_many0!(parse_hex_couple, Vec::new(), |mut acc: Vec<_>, item| {
-     acc.push(item);
-     acc
-}));
+use hex;
 
 pub fn from_hex(s: &String) -> Result<Vec<u8>, ()> {
-    match parse_hex_str(s.as_str().as_bytes()) {
-        IResult::Done(r, i) => {
-            match r.len() {
-                0 => Ok(i.to_vec()),
-                _ => Err(()),
-            }
-        },
-        _ => Err(()),
-    }
+    hex::decode(s)
+        .map_err(|_| ())
 }
 
 #[cfg(test)]

--- a/src/pass/mod.rs
+++ b/src/pass/mod.rs
@@ -129,7 +129,7 @@
 
 use std::collections::HashMap;
 
-use rand::{Rng, thread_rng};
+use rand::{RngCore, thread_rng};
 
 use ring::{self, digest};
 

--- a/src/pass/phc_encoding.rs
+++ b/src/pass/phc_encoding.rs
@@ -61,6 +61,7 @@ use super::ErrorCode;
 use std::collections::HashMap;
 use parser;
 
+/*
 macro_rules! get_salt {
     ($salt:expr) => {{
         match $salt.to_owned() {
@@ -69,6 +70,7 @@ macro_rules! get_salt {
         }
     }}
 }
+*/
 
 macro_rules! get_param {
     ($h:expr, $k:expr, $t:ty, $default:expr) => {{


### PR DESCRIPTION
This updates all dependencies to the latest version. The hex code stopped working with nom 4.0.0 so I've replaced it with the hex crate.

I would recommend to release this as 0.7.0 due to the ring update.