### PR TITLE
Apply clippy lints

### DIFF
--- a/src/oath/hotp.rs
+++ b/src/oath/hotp.rs
@@ -83,10 +83,10 @@ impl HOTP {
     fn reduce_result(&self, hs: &[u8]) -> u32 {
         let offset = (hs[hs.len() - 1] & 0xf) as usize;
         let hash = hs[offset..offset + 4].to_vec();
-        let snum: u32 = ((hash[0] as u32 & 0x7f) << 24)
-            | ((hash[1] as u32 & 0xff) << 16)
-            | ((hash[2] as u32 & 0xff) << 8)
-            | (hash[3] as u32 & 0xff);
+        let snum: u32 = ((u32::from(hash[0]) & 0x7f) << 24)
+            | ((u32::from(hash[1]) & 0xff) << 16)
+            | ((u32::from(hash[2]) & 0xff) << 8)
+            | (u32::from(hash[3]) & 0xff);
 
         let base = self.output_base.len() as u32;
         snum % base.pow(self.output_len as u32)
@@ -99,7 +99,7 @@ impl HOTP {
 
         while nb > 0 {
             code.push(self.output_base[(nb % base_len) as usize]);
-            nb = nb / base_len;
+            nb /= base_len;
         }
         while code.len() != self.output_len {
             code.push(self.output_base[0]);
@@ -163,12 +163,12 @@ impl HOTP {
     ///     .is_valid(&user_code);
     /// assert_eq!(valid, true);
     /// ```
-    pub fn is_valid(&self, code: &String) -> bool {
+    pub fn is_valid(&self, code: &str) -> bool {
         if code.len() != self.output_len {
             return false;
         }
         let ref_code = self.generate().into_bytes();
-        let code = code.clone().into_bytes();
+        let code = code.as_bytes();
 
         use ring::hmac::sign;
         let (code, ref_code) = (
@@ -249,13 +249,12 @@ impl HOTPBuilder {
 
     /// Returns the finalized HOTP object.
     pub fn finalize(&self) -> Result<HOTP, ErrorCode> {
-        match self.runtime_error {
-            Some(e) => return Err(e),
-            None => (),
+        if let Some(e) = self.runtime_error {
+            return Err(e);
         }
         match self.code_length() {
-            n if n < 1000000 => return Err(ErrorCode::CodeTooSmall),
-            n if n > 2147483648 => return Err(ErrorCode::CodeTooBig),
+            n if n < 1_000_000 => return Err(ErrorCode::CodeTooSmall),
+            n if n > 2_147_483_648 => return Err(ErrorCode::CodeTooBig),
             _ => (),
         }
         match self.key {

--- a/src/oath/mod.rs
+++ b/src/oath/mod.rs
@@ -86,19 +86,18 @@ pub enum ErrorCode {
 macro_rules! builder_common {
     ($t:ty) => {
         /// Sets the shared secret.
-        pub fn key(&mut self, key: &Vec<u8>) -> &mut $t {
-            self.key = Some(key.clone());
+        pub fn key(&mut self, key: &[u8]) -> &mut $t {
+            self.key = Some(key.to_owned());
             self
         }
 
         /// Sets the shared secret. This secret is passed as an ASCII string.
-        pub fn ascii_key(&mut self, key: &String) -> &mut $t {
-            self.key = Some(key.clone().into_bytes());
-            self
+        pub fn ascii_key(&mut self, key: &str) -> &mut $t {
+            self.key(key.as_bytes())
         }
 
         /// Sets the shared secret. This secret is passed as an hexadecimal encoded string.
-        pub fn hex_key(&mut self, key: &String) -> &mut $t {
+        pub fn hex_key(&mut self, key: &str) -> &mut $t {
             match parser::from_hex(key) {
                 Ok(k) => { self.key = Some(k); }
                 Err(_) => { self.runtime_error = Some(ErrorCode::InvalidKey); }
@@ -107,7 +106,7 @@ macro_rules! builder_common {
         }
 
         /// Sets the shared secret. This secret is passed as a base32 encoded string.
-        pub fn base32_key(&mut self, key: &String) -> &mut $t {
+        pub fn base32_key(&mut self, key: &str) -> &mut $t {
             match base32::decode(base32::Alphabet::RFC4648 { padding: false }, &key) {
                 Some(k) => { self.key = Some(k); }
                 None => { self.runtime_error = Some(ErrorCode::InvalidKey); }
@@ -134,8 +133,8 @@ macro_rules! builder_common {
         }
 
         /// Sets the base used to represents the output code. Default is "0123456789".to_owned().into_bytes().
-        pub fn output_base(&mut self, base: &Vec<u8>) -> &mut $t {
-            self.output_base = base.clone();
+        pub fn output_base(&mut self, base: &[u8]) -> &mut $t {
+            self.output_base = base.to_owned();
             self
         }
 

--- a/src/oath/totp.rs
+++ b/src/oath/totp.rs
@@ -79,7 +79,7 @@ impl TOTP {
         if timestamp < self.initial_time {
             panic!("The current Unix time is below the initial time.");
         }
-        (timestamp - self.initial_time) / self.period as u64
+        (timestamp - self.initial_time) / u64::from(self.period)
     }
 
     /// Generate the current TOTP value.
@@ -122,10 +122,10 @@ impl TOTP {
     ///     .unwrap()
     ///     .is_valid(&user_code);
     /// ```
-    pub fn is_valid(&self, code: &String) -> bool {
+    pub fn is_valid(&self, code: &str) -> bool {
         let base_counter = self.get_counter();
         for counter in
-            (base_counter - self.negative_tolerance)..(base_counter + self.positive_tolerance + 1)
+            (base_counter - self.negative_tolerance)..=(base_counter + self.positive_tolerance)
         {
             let hotp = HOTPBuilder::new()
                 .key(&self.key.clone())
@@ -260,13 +260,12 @@ impl TOTPBuilder {
 
     /// Returns the finalized TOTP object.
     pub fn finalize(&self) -> Result<TOTP, ErrorCode> {
-        match self.runtime_error {
-            Some(e) => return Err(e),
-            None => (),
+        if let Some(e) = self.runtime_error {
+            return Err(e);
         }
         match self.code_length() {
-            n if n < 1000000 => return Err(ErrorCode::CodeTooSmall),
-            n if n > 2147483648 => return Err(ErrorCode::CodeTooBig),
+            n if n < 1_000_000 => return Err(ErrorCode::CodeTooSmall),
+            n if n > 2_147_483_648 => return Err(ErrorCode::CodeTooBig),
             _ => (),
         }
         match self.key {

--- a/src/parser/hex.rs
+++ b/src/parser/hex.rs
@@ -57,7 +57,7 @@
 
 use hex;
 
-pub fn from_hex(s: &String) -> Result<Vec<u8>, ()> {
+pub fn from_hex(s: &str) -> Result<Vec<u8>, ()> {
     hex::decode(s).map_err(|_| ())
 }
 

--- a/src/pass/mod.rs
+++ b/src/pass/mod.rs
@@ -243,7 +243,7 @@ enum SupportedHashSchemes {
 
 fn from_reference_hash(
     hash_info: &PHCEncoded,
-) -> Result<Box<Fn(&str) -> Result<String, ErrorCode>>, ErrorCode> {
+) -> Result<Box<dyn Fn(&str) -> Result<String, ErrorCode>>, ErrorCode> {
     let algorithm: SupportedHashSchemes = match hash_info.id {
         Some(ref scheme_id) => match scheme_id.as_ref() {
             "pbkdf2_sha512" => SupportedHashSchemes::Pbkdf2Sha512,

--- a/src/pass/mod.rs
+++ b/src/pass/mod.rs
@@ -274,7 +274,7 @@ fn from_reference_hash(
             };
             // the output length will depend on the digest algorithm
             let output_len: usize = ring::digest::SHA256.output_len;
-            let salt: Vec<u8> = hash_info.salt().unwrap_or(Vec::new());
+            let salt: Vec<u8> = hash_info.salt().unwrap_or_default();
             Ok(Box::new(move |password: &str| {
                 let mut out: Vec<u8> = vec![0; output_len];
 
@@ -314,7 +314,7 @@ fn from_reference_hash(
             };
             let output_len: usize = ring::digest::SHA512.output_len;
             // the output length will depend on
-            let salt: Vec<u8> = hash_info.salt().unwrap_or(Vec::new());
+            let salt: Vec<u8> = hash_info.salt().unwrap_or_default();
             Ok(Box::new(move |password: &str| {
                 let mut out: Vec<u8> = vec![0; output_len];
 
@@ -438,16 +438,13 @@ pub fn is_valid(password: &str, reference: &str) -> bool {
         Err(_) => return false,
     };
 
-    match ring::pbkdf2::verify(
+    ring::pbkdf2::verify(
         algorithm,
         iterations,
         salt.as_ref(),
         password.as_bytes(),
         password_hash.as_ref(),
-    ) {
-        Ok(_) => true,
-        Err(_) => false,
-    }
+    ).is_ok()
 }
 
 #[cfg(feature = "cbindings")]


### PR DESCRIPTION
A lot of these are QOL improvements, e.g. you don't have to use a `String` anymore, but instead a `&str` can be used now (same goes for `Vec` vs `&[_]`).
Now you don't need an owned value anymore, which is very convenient.

The rest are general clippy lints, e.g. using` u32::from` instead of `as 32`, or using `is_empty` instead of `.len == 0`